### PR TITLE
Support new stats API for multi insight in one user/org setting cascade

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,38 @@
           "maximum": 1,
           "default": 0.03
         }
+      },
+      "patternProperties": {
+        "^codeStatsInsights\\.insight\\.": {
+          "anyOf": [
+            { "enum": ["null","false"]},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "title",
+                "repository"
+              ],
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "The title for the insight"
+                },
+                "repository": {
+                  "type": "string",
+                  "description": "The title for the insight"
+                },
+                "otherThreshold": {
+                  "type": "number",
+                  "description": "The threshold below which a language is counted as part of 'Other'",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 0.03
+                }
+              }
+            }
+          ]
+        }
       }
     }
   },

--- a/src/code-stats-insights.ts
+++ b/src/code-stats-insights.ts
@@ -1,121 +1,195 @@
 import * as sourcegraph from 'sourcegraph'
 import { from, defer } from 'rxjs'
-import { switchMap, map, retry } from 'rxjs/operators'
-import { IQuery, IGraphQLResponseRoot } from './schema'
+import { map, retry, startWith, distinctUntilChanged, mergeAll } from 'rxjs/operators'
 import gql from 'tagged-template-noop'
 import { escapeRegExp, partition, sum } from 'lodash'
+import isEqual from 'lodash/isEqual'
 import linguistLanguages from 'linguist-languages'
+import { isLinguistLanguage, parseUri, queryGraphQL } from './utils';
 
-const isLinguistLanguage = (language: string): language is keyof typeof linguistLanguages =>
-    Object.prototype.hasOwnProperty.call(linguistLanguages, language)
+/**
+ * Code stat insight settings from user/org setting cascade.
+ * */
+interface Insight {
+    title: string
+    repository?: string;
+    otherThreshold?: number
 
-const queryGraphQL = async <T = IQuery>(query: string, variables: object = {}): Promise<T> => {
-    const { data, errors }: IGraphQLResponseRoot = await sourcegraph.commands.executeCommand(
-        'queryGraphQL',
-        query,
-        variables
-    )
-    if (errors && errors.length > 0) {
-        throw new Error(errors.map(e => e.message).join('\n'))
-    }
-    return (data as any) as T
+    /**
+     *  Synthetic field for backward compatibility.
+     *  In first version of code stats insight this query supposed to be filled
+     *  by users in user/org settings. Now we don't need set this field because
+     *  we can derive query from repository field. But for the sake of compatibility
+     *  of existing first-version insights we left this setting.
+     * */
+    query?: string;
 }
 
-const parseUri = (uri: URL): { repo: string } => {
-    return { repo: uri.hostname + uri.pathname }
-}
-
+/**
+ * Code stats insight extension.
+ * Sourcegraph extension documentation: https://docs.sourcegraph.com/extensions/authoring
+ *
+ * This extension supports two public API in user/org  setting cascade
+ *
+ * 1. Old API (only one code stats insight can live for entire setting cascade)
+ *
+ * "codeStatsInsights.query": "repo:^github\\.com/sourcegraph/sourcegraph$",
+ * "codeStatsInsights.otherThreshold": 0.01,
+ *
+ * 2. New API (any number of stats insight can be create in user/org setting cascade)
+ *
+ * "codeStatsInsights.insight.sourcegraphLanguageUsage": {
+ *      "title": "Sourcegraph Language Usage",
+ *      "repository": "github.com/sourcegraph/sourcegraph",
+ *      "otherThreshold": "0.03"
+ * }
+ * */
 export function activate(context: sourcegraph.ExtensionContext): void {
-    const provideView = ({ viewer }: { viewer?: sourcegraph.DirectoryViewer }) => {
-        return from(sourcegraph.configuration).pipe(
-            map(() => sourcegraph.configuration.get().value),
-            switchMap(configuration => {
-                if (!configuration['codeStatsInsights.query']) {
-                    return []
-                }
+    const settings = from(sourcegraph.configuration).pipe(
+        startWith(null),
+        map(() => sourcegraph.configuration.get().value)
+    )
+
+    // Observe stats insights settings from user/org setting cascade
+    const insightChanges = settings.pipe(
+        map(settings => {
+                const insightsFromCreationFlow = Array.from(Object.entries(settings))
+                    .filter(([key]) =>
+                        key.startsWith('codeStatsInsights.insight.')) as [string, Insight | null | false][];
+
+                // In a first version of this extension we had different approach hot to set settings
+                // for the sake of backward compatibility we support this old API as well here
+                const insightFromOldAPI: [string, Insight | null] = [
+                    'codeStatsInsight.language',
+                    settings['codeStatsInsights.query']
+                        ? {
+                            title: 'Language usage',
+                            query: settings['codeStatsInsights.query'],
+                            otherThreshold: settings['codeStatsInsights.otherThreshold']
+                          } as Insight
+                        : null
+                ]
+
+
+                return [...insightsFromCreationFlow, insightFromOldAPI]
+            }
+        ),
+        distinctUntilChanged((a, b) => isEqual(a, b))
+    )
+
+    context.subscriptions.add(
+        insightChanges.pipe(
+            mergeAll()
+        ).subscribe(([id, insight]) => {
+            if (!insight) {
+                return
+            }
+
+            const { repository, query: querySetting } = insight;
+            const viewProviderId = `codeStatsInsight.${id}`
+
+            const provideView = ({ viewer }: { viewer?: sourcegraph.DirectoryViewer }): Promise<sourcegraph.View> => {
+
                 const query = viewer
+                    // Show current repo stats instead of repo which has been specified
+                    // in code stats settings.
                     ? `repo:^${escapeRegExp(parseUri(viewer.directory.uri).repo)}$`
-                    : configuration['codeStatsInsights.query']
-                return defer(() =>
-                    queryGraphQL(
-                        gql`
-                            query SearchResultsStats($query: String!) {
-                                search(query: $query) {
-                                    results {
-                                        limitHit
-                                    }
-                                    stats {
-                                        languages {
-                                            name
-                                            totalLines
-                                        }
-                                    }
-                                }
-                            }
-                        `,
-                        { query }
-                    )
-                ).pipe(
-                    retry(3),
-                    map(data => data.search!.stats),
-                    map(
-                        (stats): sourcegraph.View => {
-                            const totalLines = sum(stats.languages.map(language => language.totalLines))
-                            const linkURL = new URL('/stats', sourcegraph.internal.sourcegraphURL)
-                            linkURL.searchParams.set('q', query)
-                            const otherThreshold = configuration['codeStatsInsights.otherThreshold'] ?? 0.03
-                            const [notOther, other] = partition(
-                                stats.languages,
-                                language => language.totalLines / totalLines >= otherThreshold
-                            )
-                            return {
-                                title: configuration['codeStatsInsights.title'] ?? 'Language usage',
-                                content: [
-                                    {
-                                        chart: 'pie',
-                                        pies: [
-                                            {
-                                                data: [
-                                                    ...notOther,
-                                                    {
-                                                        name: 'Other',
-                                                        totalLines: sum(other.map(language => language.totalLines)),
-                                                    },
-                                                ].map(language => ({
-                                                    ...language,
-                                                    fill:
-                                                        (isLinguistLanguage(language.name) &&
-                                                            linguistLanguages[language.name].color) ||
-                                                        'gray',
-                                                    linkURL: linkURL.href,
-                                                })),
-                                                dataKey: 'totalLines',
-                                                nameKey: 'name',
-                                                fillKey: 'fill',
-                                                linkURLKey: 'linkURL',
-                                            },
-                                        ],
-                                    },
-                                ],
+                    : querySetting
+                        // Show query from old version of code stats insight with full query string
+                        ? querySetting
+                        // Calculate query string base on repository string from insight settings
+                        // this is new approach if user setup insight by creation UI.
+                        : `repo:^${escapeRegExp(repository)}`
+
+
+                return getInsightContent(query, insight);
+            }
+
+            context.subscriptions.add(
+                sourcegraph.app.registerViewProvider(`${viewProviderId}.insightsPage`, {
+                    where: 'insightsPage',
+                    provideView,
+                })
+            )
+
+            context.subscriptions.add(
+                sourcegraph.app.registerViewProvider(`${viewProviderId}.directory`, {
+                    where: 'directory',
+                    provideView,
+                })
+            )
+        })
+    )
+}
+
+async function getInsightContent(query: string, insight: Insight): Promise<sourcegraph.View> {
+    // Fetch raw stats for code insight.
+    const stats = await defer(() =>
+        queryGraphQL(
+            gql`
+             query SearchResultsStats($query: String!) {
+                    search(query: $query) {
+                        results {
+                            limitHit
+                        }
+                        stats {
+                            languages {
+                                name
+                                totalLines
                             }
                         }
-                    )
-                )
-            })
+                    }
+                }
+            `,
+            { query }
         )
+    )
+        .pipe(
+            // The search may timeout, but a retry is then likely faster because caches are warm
+            retry(3),
+            map(data => data.search!.stats),
+        )
+        .toPromise()
+
+    const totalLines = sum(stats.languages.map(language => language.totalLines))
+    const linkURL = new URL('/stats', sourcegraph.internal.sourcegraphURL)
+
+    linkURL.searchParams.set('q', query)
+
+    const otherThreshold = insight.otherThreshold ?? 0.03
+    const [notOther, other] = partition(
+        stats.languages,
+        language => language.totalLines / totalLines >= otherThreshold
+    )
+    return {
+        title: insight.title,
+        content: [
+            {
+                chart: 'pie',
+                pies: [
+                    {
+                        data: [
+                            ...notOther,
+                            {
+                                name: 'Other',
+                                totalLines: sum(other.map(language => language.totalLines)),
+                            },
+                        ].map(language => ({
+                            ...language,
+                            fill:
+                                (isLinguistLanguage(language.name) &&
+                                    linguistLanguages[language.name].color) ||
+                                'gray',
+                            linkURL: linkURL.href,
+                        })),
+                        dataKey: 'totalLines',
+                        nameKey: 'name',
+                        fillKey: 'fill',
+                        linkURLKey: 'linkURL',
+                    },
+                ],
+            },
+        ],
     }
-    context.subscriptions.add(
-        sourcegraph.app.registerViewProvider('codeStatsInsights.languages.insightsPage', {
-            where: 'insightsPage',
-            provideView,
-        })
-    )
-    context.subscriptions.add(
-        sourcegraph.app.registerViewProvider('codeStatsInsights.languages.directory', {
-            where: 'directory',
-            provideView,
-        })
-    )
 }
 
-// Sourcegraph extension documentation: https://docs.sourcegraph.com/extensions/authoring

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,22 @@
+import linguistLanguages from 'linguist-languages';
+import { IGraphQLResponseRoot, IQuery } from './schema';
+import sourcegraph from 'sourcegraph';
+
+export const isLinguistLanguage = (language: string): language is keyof typeof linguistLanguages =>
+    Object.prototype.hasOwnProperty.call(linguistLanguages, language)
+
+export const queryGraphQL = async <T = IQuery>(query: string, variables: object = {}): Promise<T> => {
+    const { data, errors }: IGraphQLResponseRoot = await sourcegraph.commands.executeCommand(
+        'queryGraphQL',
+        query,
+        variables
+    )
+    if (errors && errors.length > 0) {
+        throw new Error(errors.map(e => e.message).join('\n'))
+    }
+    return (data as any) as T
+}
+
+export const parseUri = (uri: URL): { repo: string } => {
+    return { repo: uri.hostname + uri.pathname }
+}


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph-code-stats-insights/issues/4

This PR is adding support for the new API of stats extension in the user/org setting cascade. New API allows users have more than just one code stats insight. 

**Example of new API**

```
 "codeStatsInsights.insight.sourcegraphLanguages: {
    "title": "Sourcegraph languages usage"
    "query": "repo:^github\\.com/sourcegraph/sourcegraph$",
    "otherThreshold": 0.02,
  }
```

For backward compatibility, we still support old API 

**Example of old API**

 ```
 "codeStatsInsights.query": "repo:^github\\.com/sourcegraph/sourcegraph$",
  "codeStatsInsights.otherThreshold": 0.02,
```